### PR TITLE
Fix of issue #5: numeric clients & hosts

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -41,8 +41,8 @@ class Client {
         }
 
         // find free username
-        const user = await User.free(this.name,'C');
-        const clientFolder = convert(this.name, '-a-z0-9_\.','F');
+        const user = await User.free(this.name,'c');
+        const clientFolder = convert(this.name, '-a-z0-9_\.','c');
 
         const home = this.config.get('clientPath') + '/' + clientFolder;
         await User.create(user, home);

--- a/src/client.js
+++ b/src/client.js
@@ -41,8 +41,8 @@ class Client {
         }
 
         // find free username
-        const user = await User.free(this.name);
-        const clientFolder = convert(this.name, '-a-z0-9_\.');
+        const user = await User.free(this.name,'C');
+        const clientFolder = convert(this.name, '-a-z0-9_\.','F');
 
         const home = this.config.get('clientPath') + '/' + clientFolder;
         await User.create(user, home);

--- a/src/client.js
+++ b/src/client.js
@@ -14,7 +14,7 @@ const createHomeFolder = async (name, home) => {
 // client class
 class Client {
     constructor(name) {
-        this.name = name;
+        this.name = ''+name;
         this.hostnames = {};
         this.db = Registry.get('Database');
         this.config = Registry.get('Config');

--- a/src/helper/convert.js
+++ b/src/helper/convert.js
@@ -1,14 +1,43 @@
 import { Iconv } from 'iconv';
 
 // removes special chars
-const convert = (name, allowedChars) => {
+//
+// 3 type options for cases where the start of name is a number
+// - C = client (default) adds a letter "c" in front of the username
+// - H = host, adds the letter "h" to the front of the username
+// - F = folder, doesn't modify the folder name
+const convert = (name, allowedChars, type) => {
+
+    switch(type)
+    {
+        case 'H':
+		var nameRegex = 'h$&';
+		break;
+	case 'F':
+		var nameRegex = '$&';
+		break;	 
+        case 'C':
+		var nameRegex = 'c$&';
+		break;
+        default:
+		var nameRegex = 'c$&';
+		break;
+    }
+
+    // if the name is number-only, convert it
+    if (typeof name == 'number')
+    {
+	var n = name.toString();
+	name = n;
+    }
+	
     allowedChars = allowedChars || '-a-z0-9_';
 
     let iconv = new Iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE');
     return iconv.convert(name).toString()
                 .toLowerCase()
                 .replace(new RegExp('[^' + allowedChars + ']', 'g'), '')
-                .replace(/^[0-9]+/g, '')
+                .replace(/^[0-9]+/g, nameRegex )
                 .substr(0, 32);
 };
 

--- a/src/helper/convert.js
+++ b/src/helper/convert.js
@@ -8,36 +8,21 @@ import { Iconv } from 'iconv';
 // - F = folder, doesn't modify the folder name
 const convert = (name, allowedChars, type) => {
 
-    switch(type)
-    {
-        case 'H':
-		var nameRegex = 'h$&';
-		break;
-	case 'F':
-		var nameRegex = '$&';
-		break;	 
-        case 'C':
-		var nameRegex = 'c$&';
-		break;
-        default:
-		var nameRegex = 'c$&';
-		break;
+    if(type == 'f') {
+        var nameReplace = '$&';
+    } else {
+        var nameReplace = type+'$&';
     }
 
-    // if the name is number-only, convert it
-    if (typeof name == 'number')
-    {
-	var n = name.toString();
-	name = n;
-    }
-	
+    console.log('nameReplace = '+nameReplace);
+
     allowedChars = allowedChars || '-a-z0-9_';
 
     let iconv = new Iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE');
-    return iconv.convert(name).toString()
+    return iconv.convert(''+name).toString()
                 .toLowerCase()
                 .replace(new RegExp('[^' + allowedChars + ']', 'g'), '')
-                .replace(/^[0-9]+/g, nameRegex )
+                .replace(/^[0-9]+/g, nameReplace )
                 .substr(0, 32);
 };
 

--- a/src/helper/convert.js
+++ b/src/helper/convert.js
@@ -17,7 +17,7 @@ const convert = (name, allowedChars, type) => {
     allowedChars = allowedChars || '-a-z0-9_';
 
     let iconv = new Iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE');
-    return iconv.convert(''+name).toString()
+    return iconv.convert(name).toString()
                 .toLowerCase()
                 .replace(new RegExp('[^' + allowedChars + ']', 'g'), '')
                 .replace(/^[0-9]+/g, numericPrefix )

--- a/src/helper/convert.js
+++ b/src/helper/convert.js
@@ -9,12 +9,10 @@ import { Iconv } from 'iconv';
 const convert = (name, allowedChars, type) => {
 
     if(type == 'f') {
-        var nameReplace = '$&';
+        var numericPrefix = '$&';
     } else {
-        var nameReplace = type+'$&';
+        var numericPrefix = type+'$&';
     }
-
-    console.log('nameReplace = '+nameReplace);
 
     allowedChars = allowedChars || '-a-z0-9_';
 
@@ -22,7 +20,7 @@ const convert = (name, allowedChars, type) => {
     return iconv.convert(''+name).toString()
                 .toLowerCase()
                 .replace(new RegExp('[^' + allowedChars + ']', 'g'), '')
-                .replace(/^[0-9]+/g, nameReplace )
+                .replace(/^[0-9]+/g, numericPrefix )
                 .substr(0, 32);
 };
 

--- a/src/helper/user.js
+++ b/src/helper/user.js
@@ -63,8 +63,9 @@ const remove = async (name, backupFolder) => {
 };
 
 // returns a valid free user based on name
-const free = async (name) => {
-    const validUser = await convert(name);
+const free = async (name,type) => {
+    const validUser = await convert(name,'',type);
+
     var freeUser = validUser;
     var index = 0;
     while (await exists(freeUser)) {

--- a/src/host.js
+++ b/src/host.js
@@ -40,7 +40,7 @@ const loadTemplate = readFile(__dirname + '/templates/vhost.hbs', 'utf-8')
 class Host {
     constructor(client, name) {
         this.client = client;
-        this.name = name;
+        this.name = ''+name;
         this.db = Registry.get('Database');
     }
 

--- a/src/host.js
+++ b/src/host.js
@@ -66,8 +66,8 @@ class Host {
         }
 
         // find free username and collect data for database
-        const user = await User.free(this.name);
-        const hostFolder = convert(this.name, '-a-z0-9_\.');
+        const user = await User.free(this.name,'H');
+        const hostFolder = convert(this.name,'-a-z0-9_\.','F');
         const clientInfo = await this.client.info();
         const home = `${clientInfo.path}/${hostFolder}`;
 

--- a/src/host.js
+++ b/src/host.js
@@ -66,8 +66,8 @@ class Host {
         }
 
         // find free username and collect data for database
-        const user = await User.free(this.name,'H');
-        const hostFolder = convert(this.name,'-a-z0-9_\.','F');
+        const user = await User.free(this.name,'h');
+        const hostFolder = convert(this.name,'-a-z0-9_\.','f');
         const clientInfo = await this.client.info();
         const home = `${clientInfo.path}/${hostFolder}`;
 


### PR DESCRIPTION
avanti now allows the use of full numeric clients & hosts.

Mainly handled by the convert function, there are 3 behaviours controlled by the type parameter:
c (client)
-> if client name starts with a number, a 'c' is prefixed to the username in order to comply with Ubuntu username regex

h (host)
-> idem, just a 'h' is prefixed

f (folder)
-> as the foldername are not restricted, host folders will be passed through